### PR TITLE
set auth_init to false after AuthStop is successful

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -236,6 +236,9 @@ func AuthStop() {
 	if auth_verbose {
 		fmt.Println("AUTH: Stopped")
 	}
+
+	auth_init = false
+
 }
 
 // Allow (whitelist) some IP addresses.


### PR DESCRIPTION
After a while I discovered that closing zmq.AuthStart() with zmq.AuthStop() and then starting auth again throws the error: "Auth is already running".

So auth_init should be set to false after AuthStop is successful (auth.go).
