### PR TITLE
Add SetXpubVerboseUnsubscribe()

### DIFF
--- a/socketset.go
+++ b/socketset.go
@@ -272,6 +272,13 @@ func (soc *Socket) SetXpubVerbose(value int) error {
 	return soc.setInt(C.ZMQ_XPUB_VERBOSE, value)
 }
 
+// ZMQ_XPUB_VERBOSE_UNSUBSCRIBE: provide all unsubscription messages on XPUB sockets
+//
+// See: XXX
+func (soc *Socket) SetXpubVerboseUnsubscribe(value int) error {
+	return soc.setInt(C.ZMQ_XPUB_VERBOSE_UNSUBSCRIBE, value)
+}
+
 // ZMQ_REQ_CORRELATE: match replies with requests
 //
 // See: http://api.zeromq.org/4-1:zmq-setsockopt#toc33


### PR DESCRIPTION
The new flag `ZMQ_XPUB_VERBOSE_UNSUBSCRIBE` was added to `zmq_setsockopt()` upstream, here you can see the commit:

https://github.com/zeromq/libzmq/commit/ec5592db1f87cd18e61545be4a3a3174709736dc

I was thinking to leaving this PR open here until there is a new release of zmq4 and the API has this new flag in place. I'll update the reference to the right link in the doc.