### PR TITLE
added defer to mdcli2 ConnectToBroker()

### DIFF
--- a/examples/mdapi/mdcliapi2.go
+++ b/examples/mdapi/mdcliapi2.go
@@ -39,6 +39,7 @@ func (mdcli2 *Mdcli2) ConnectToBroker() (err error) {
 		mdcli2.client = nil
 	}
 	mdcli2.client, err = zmq.NewSocket(zmq.DEALER)
+	defer mdcli2.client.Close()
 	if err != nil {
 		if mdcli2.verbose {
 			log.Println("E: ConnectToBroker() creating socket failed")


### PR DESCRIPTION
When trying to use mdcli2 api, it doesn't work. There is no defer close, so the socket is closed too early and no messages are sent. Adding this fixes the issue and makes the example code work again.