### PR TITLE
Fix error message

### DIFF
--- a/draft/zmq4.go
+++ b/draft/zmq4.go
@@ -144,8 +144,8 @@ func init() {
 			initVersionError =
 				fmt.Errorf(
 					"zmq4 was installed with ZeroMQ version %d.%d.%d, but the application links with version %d.%d.%d",
-					int(C.zmq4_major), int(C.zmq4_minor), int(C.zmq4_patch),
-					major, minor, patch)
+					major, minor, patch,
+					int(C.zmq4_major), int(C.zmq4_minor), int(C.zmq4_patch))
 			return
 		}
 	}

--- a/zmq4.go
+++ b/zmq4.go
@@ -142,8 +142,8 @@ func init() {
 			initVersionError =
 				fmt.Errorf(
 					"zmq4 was installed with ZeroMQ version %d.%d.%d, but the application links with version %d.%d.%d",
-					int(C.zmq4_major), int(C.zmq4_minor), int(C.zmq4_patch),
-					major, minor, patch)
+					major, minor, patch,
+					int(C.zmq4_major), int(C.zmq4_minor), int(C.zmq4_patch))
 			return
 		}
 	}


### PR DESCRIPTION
Error message versions appear to be reversed? `zmq_version()` seems to report the zmq version on the system that the app is installed to.