### PR TITLE
fix panic in call retry gets called after a socket has been closed and the context set to nil

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -92,7 +92,7 @@ func AsErrno(err error) Errno {
 }
 
 func (ctx *Context) retry(err error) bool {
-	if !ctx.retryEINTR || err == nil {
+	if ctx == nil || !ctx.retryEINTR || err == nil {
 		return false
 	}
 	eno, ok := err.(syscall.Errno)


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x56ee34]
goroutine 22 [running]:
github.com/pebbe/zmq4.(*Context).retry(...)
	/.cache/go-mod/github.com/pebbe/zmq4@v1.2.7/errors.go:95
github.com/pebbe/zmq4.(*Socket).RecvBytes(0xc00018f3e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/.cache/go-mod/github.com/pebbe/zmq4@v1.2.7/zmq4.go:1082 +0xf4
github.com/pebbe/zmq4.(*Socket).Recv(...)
	/.cache/go-mod/github.com/pebbe/zmq4@v1.2.7/zmq4.go:1061
github.com/pebbe/zmq4.(*Socket).RecvMessage(0xc00018f3e0, 0x0, 0x2, 0x2, 0x2, 0x0, 0x0)
	/.cache/go-mod/github.com/pebbe/zmq4@v1.2.7/utils.go:115 +0x85
```
