### PR TITLE
doc: fix wrong documentation link for socket unbind

### DIFF
--- a/zmq4.go
+++ b/zmq4.go
@@ -981,7 +981,7 @@ func (soc *Socket) Bind(endpoint string) error {
 /*
 Stop accepting connections on a socket.
 
-For a description of endpoint, see: http://api.zeromq.org/4-1:zmq-bind#toc2
+For a description of endpoint, see: http://api.zeromq.org/4-1:zmq-unbind#toc2
 */
 func (soc *Socket) Unbind(endpoint string) error {
 	if !soc.opened {


### PR DESCRIPTION
Fixes a wrong link that previously pointed to http://api.zeromq.org/4-1:zmq-bind#toc2 while the correct one should be http://api.zeromq.org/4-1:zmq-unbind#toc2.