### PR TITLE
fix: CGO issues preventing use of `zmq4/draft` on Windows

### DIFF
--- a/draft/socketget_windows.go
+++ b/draft/socketget_windows.go
@@ -4,9 +4,12 @@ package zmq4
 
 /*
 #include <zmq.h>
+#include <winsock2.h>
 #include "zmq4.h"
 */
 import "C"
+
+// winsock2.h needed for ZeroMQ version 4.3.3
 
 import (
 	"unsafe"

--- a/draft/zmq4.go
+++ b/draft/zmq4.go
@@ -2,8 +2,7 @@ package zmq4
 
 /*
 #cgo !windows pkg-config: libzmq
-#cgo windows CFLAGS: -I/usr/local/include -DZMQ_BUILD_DRAFT_API=1
-#cgo windows LDFLAGS: -L/usr/local/lib -lzmq
+#cgo windows CFLAGS: -DZMQ_BUILD_DRAFT_API=1
 #include <zmq.h>
 #if ZMQ_VERSION_MINOR < 2
 #include <zmq_utils.h>


### PR DESCRIPTION
Fixes:
- remove hardcoded LDFLAGS and include path for draft (windows)
  - on Windows, we set CFLAGS/LDFLAGS manually as per [README.md](https://github.com/pebbe/zmq4?tab=readme-ov-file#windows)
- add missing winsock2.h for draft (windows)
  - duplicated [this fix](https://github.com/pebbe/zmq4/commit/c98bc2941b0735ff0d5b63eaa98bd6e283d041c7) for `draft/socketget_windows.go` (see https://github.com/pebbe/zmq4/issues/152#issuecomment-738926197)