### PR TITLE
feat: Add ChanAdapter to bridge ZeroMQ sockets with channel-based communication

### DIFF
--- a/chanadapter.go
+++ b/chanadapter.go
@@ -1,0 +1,272 @@
+package zmq4
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+)
+
+// ChanAdapter provides a Go channel-based interface for ZeroMQ sockets.
+// It bridges the gap between ZeroMQ's message-passing model and Go's channel-based
+// concurrency model by creating receive (Rx) and transmit (Tx) channels that can be
+// used in standard Go select statements and channel operations.
+//
+// The adapter runs two internal goroutines: one for routing incoming messages
+// from the ZMQ socket to the Rx channel, and another for sending messages
+// from the Tx channel to the ZMQ socket.
+type ChanAdapter struct {
+	socket         *Socket
+	pairAddr       string
+	rxChan         chan [][]byte
+	txChan         chan [][]byte
+	sendBufferChan chan [][]byte
+	closeOnce      sync.Once
+	closeChan      func()
+	ctxCancel      func()
+	wg             sync.WaitGroup
+}
+
+var (
+	chanAdapterUniqueID atomic.Uint64
+	chanAdapterOpClose  = []byte{0x0} // the adapter is being closed
+	chanAdapterOpSend   = []byte{0x1} // send a message to the ZMQ socket
+)
+
+// NewChanAdapter creates a new ChanAdapter for the given ZMQ socket.
+// The rxChanSize parameter specifies the buffer size for the receive channel,
+// and txChanSize specifies the buffer size for the transmit channel.
+//
+// The adapter must be started with Start() and should be closed with Close()
+// when no longer needed to ensure proper cleanup of resources.
+//
+// Example:
+//
+//	socket, err := zmq4.NewSocket(zmq4.REQ)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	socket.Connect("<socket-address>")
+//
+//	adapter := zmq4.NewChanAdapter(socket, 100, 100)
+//	defer adapter.Close()
+//
+//	// Start the adapter with a context for cancellation
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//	adapter.Start(ctx)
+//
+//	msg := [][]byte{[]byte("Hello"), []byte("World")}
+//	adapter.TxChan() <- msg
+//
+//	rxChan := adapter.RxChan()
+//
+//	select {
+//	case msg, ok := <-rxChan:
+//		// Handle incoming message
+//	case <-time.After(time.Second):
+//		// Handle timeout
+//	}
+func NewChanAdapter(socket *Socket, rxChanSize int, txChanSize int) *ChanAdapter {
+	pairAddr := fmt.Sprintf("inproc://zmq-chan-transceiver-%d", chanAdapterUniqueID.Add(1))
+	rxChan := make(chan [][]byte, rxChanSize)
+	txChan := make(chan [][]byte, txChanSize)
+	sendBufferChan := make(chan [][]byte) // unbuffered channel
+
+	closeChan := func() {
+		close(rxChan)
+		close(txChan)
+		close(sendBufferChan)
+	}
+
+	return &ChanAdapter{
+		socket:         socket,
+		pairAddr:       pairAddr,
+		rxChan:         rxChan,
+		txChan:         txChan,
+		sendBufferChan: sendBufferChan,
+		closeChan:      closeChan,
+	}
+}
+
+// RxChan returns a receive-only channel for incoming messages from the ZMQ socket.
+// Messages received on the underlying ZMQ socket will be forwarded to this channel
+// as byte slice arrays, where each element represents a message part in multi-part messages.
+//
+// The channel will be closed when the adapter is shut down.
+func (t *ChanAdapter) RxChan() <-chan [][]byte {
+	return t.rxChan
+}
+
+// TxChan returns a send-only channel for outgoing messages to the ZMQ socket.
+// Messages sent to this channel will be forwarded to the underlying ZMQ socket.
+// Each message should be provided as a byte slice array, where each element
+// represents a message part for multi-part messages.
+//
+// The channel will be closed when the adapter is shut down.
+func (t *ChanAdapter) TxChan() chan<- [][]byte {
+	return t.txChan
+}
+
+// Start begins the adapter's operation by launching two background goroutines:
+// one for routing messages from the ZMQ socket to the receive channel, and
+// another for routing messages from the transmit channel to the ZMQ socket.
+//
+// The provided context can be used to cancel the adapter's operation.
+// When the context is cancelled or Close() is called, both goroutines will
+// be shut down gracefully.
+//
+// Start should only be called once per adapter instance.
+func (t *ChanAdapter) Start(ctx context.Context) {
+	childCtx, cancel := context.WithCancel(ctx)
+	t.ctxCancel = cancel
+
+	t.wg.Add(2)
+	go t.runRouterLoop(childCtx)
+	go t.runSenderLoop(childCtx)
+}
+
+// runRouterLoop handles incoming messages from the ZMQ socket and internal
+// coordination messages from the sender loop. It forwards socket messages
+// to the receive channel and processes send requests from the sender loop.
+func (t *ChanAdapter) runRouterLoop(_ context.Context) {
+	var err error
+	defer t.wg.Done()
+	defer t.ctxCancel()
+
+	pair, err := NewSocket(PAIR)
+	if err != nil {
+		log.Println("E: failed to create PAIR socket")
+		return
+	}
+	defer pair.Close()
+
+	err = pair.Bind(t.pairAddr)
+	if err != nil {
+		log.Println("E: failed to connect PAIR socket")
+		return
+	}
+
+	poller := NewPoller()
+	poller.Add(t.socket, POLLIN)
+	poller.Add(pair, POLLIN)
+
+	for {
+		events, err := poller.PollAll(-1)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		if len(events) == 0 {
+			log.Println("I: socket timeout")
+			continue
+		}
+
+		for _, item := range events {
+			switch s := item.Socket; s {
+			case pair:
+				if item.Events&POLLIN != 0 {
+					opCode, err := pair.RecvBytes(0)
+					if err != nil {
+						log.Println(err)
+						continue
+					}
+
+					if bytes.Equal(opCode, chanAdapterOpClose) {
+						return
+					} else if bytes.Equal(opCode, chanAdapterOpSend) {
+						msg, ok := <-t.sendBufferChan
+						if !ok {
+							log.Println("E: sendBufferChan is closed")
+							return
+						}
+						// send the message payload to the ZMQ socket
+						_, err = t.socket.SendMessage(msg)
+						if err != nil {
+							log.Println("E: failed to send message to socket. ", err)
+							continue
+						}
+					}
+				}
+			case t.socket:
+				if item.Events&POLLIN != 0 {
+					// process incoming messages
+					msg, err := t.socket.RecvMessageBytes(0)
+					if err != nil {
+						log.Println(err)
+						continue
+					}
+					// forward the message to rxChan
+					t.rxChan <- msg
+				}
+			}
+
+		}
+	}
+
+}
+
+// runSenderLoop handles outgoing messages from the transmit channel.
+// It coordinates with the router loop via an internal PAIR socket to
+// ensure thread-safe message transmission to the ZMQ socket.
+func (t *ChanAdapter) runSenderLoop(ctx context.Context) {
+	var err error
+	defer t.wg.Done()
+	defer t.ctxCancel()
+
+	pair, err := NewSocket(PAIR)
+	if err != nil {
+		log.Println("E: failed to create PAIR socket")
+		return
+	}
+	defer pair.Close()
+
+	err = pair.Connect(t.pairAddr)
+	if err != nil {
+		log.Println("E: failed to connect PAIR socket")
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// ensure the router loop is closed gracefully
+			_, err = pair.SendBytes(chanAdapterOpClose, 0)
+			if err != nil {
+				log.Println("E: failed to send close message")
+			}
+			return
+		case msg, ok := <-t.txChan:
+			if !ok {
+				log.Println("E: txChan is closed")
+				return
+			}
+			_, err = pair.SendBytes(chanAdapterOpSend, 0)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+			// block until the message payload is recieved by Router loop
+			t.sendBufferChan <- msg
+		}
+	}
+}
+
+// Close gracefully shuts down the adapter by cancelling the context,
+// waiting for all goroutines to complete, and closing all channels.
+// It's safe to call Close multiple times.
+//
+// After Close is called, the receive and transmit channels will be closed
+// and no further message processing will occur.
+func (t *ChanAdapter) Close() {
+	if t.ctxCancel != nil {
+		t.ctxCancel()
+	}
+	t.wg.Wait()
+	if t.closeChan != nil {
+		t.closeOnce.Do(t.closeChan)
+	}
+}

--- a/chanadapter_test.go
+++ b/chanadapter_test.go
@@ -1,0 +1,638 @@
+package zmq4
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type ChanAdapterTestCase struct {
+	// Begin of test case parameters
+	socketAddr string
+	rxChanSize int
+	txChanSize int
+	identity   []byte
+	// End of test case parameters
+	bindSocket     *Socket
+	bindAdapter    *ChanAdapter
+	cancel         func()
+	connectSocket  *Socket
+	connectAdapter *ChanAdapter
+}
+
+func (tc *ChanAdapterTestCase) setUp(t *testing.T, connectType, bindType Type) {
+	tc.bindSocket, _ = NewSocket(bindType)
+	tc.bindSocket.Bind(tc.socketAddr)
+	tc.bindAdapter = NewChanAdapter(tc.bindSocket, tc.rxChanSize, tc.txChanSize)
+
+	tc.connectSocket, _ = NewSocket(connectType)
+	if tc.identity != nil {
+		tc.connectSocket.SetIdentity(string(tc.identity[:]))
+	}
+	tc.connectSocket.Connect(tc.socketAddr)
+	tc.connectAdapter = NewChanAdapter(tc.connectSocket, tc.rxChanSize, tc.txChanSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tc.cancel = cancel
+	tc.bindAdapter.Start(ctx)
+	tc.connectAdapter.Start(ctx)
+
+	t.Cleanup(func() {
+		if tc.cancel != nil {
+			tc.cancel()
+		}
+		if tc.bindAdapter != nil {
+			tc.bindAdapter.Close()
+		}
+		if tc.connectAdapter != nil {
+			tc.connectAdapter.Close()
+		}
+		if tc.bindSocket != nil {
+			tc.bindSocket.SetLinger(0)
+			tc.bindSocket.Close()
+		}
+		if tc.connectSocket != nil {
+			tc.connectSocket.SetLinger(0)
+			tc.connectSocket.Close()
+		}
+	})
+}
+
+// Test cases
+func TestChanAdapterReq2Rep(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test
+	requestMsg := [][]byte{[]byte("Hello, world!")}
+	replyMsg := [][]byte{[]byte("Ack")}
+
+	tc.connectAdapter.TxChan() <- requestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, requestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- replyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, replyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterReq2Router(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+		identity:   []byte("client-12345"),
+	}
+	tc.setUp(t, REQ, ROUTER)
+
+	// Test
+	emptyDelimiter := []byte{}
+	routeHeader := [][]byte{tc.identity, emptyDelimiter}
+	replyMsg := [][]byte{[]byte("Reply")}
+	requestMsg := [][]byte{[]byte("Request"), []byte("Hello, world!")}
+	recvRequestMsg := append(routeHeader, requestMsg...)
+	sendReplyMsg := append(routeHeader, replyMsg...)
+
+	tc.connectAdapter.TxChan() <- requestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvRequestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- sendReplyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, replyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterDealer2Router(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+		identity:   []byte("client-12345"),
+	}
+	tc.setUp(t, DEALER, ROUTER)
+
+	// Test
+	emptyDelimiter := []byte{}
+	routeHeader := [][]byte{tc.identity, emptyDelimiter}
+	dealerHeader := [][]byte{emptyDelimiter}
+	replyMsg := [][]byte{[]byte("Reqly")}
+	requestMsg := [][]byte{[]byte("Request"), []byte("Hello, world!")}
+	sendRequestMsg := append(dealerHeader, requestMsg...)
+	recvRequestMsg := append(routeHeader, requestMsg...)
+	sendReplyMsg := append(routeHeader, replyMsg...)
+	recvReplyMsg := append(dealerHeader, replyMsg...)
+
+	tc.connectAdapter.TxChan() <- sendRequestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvRequestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- sendReplyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvReplyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterReconnectDealer2Router(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+		identity:   []byte("client-12345"),
+	}
+	tc.setUp(t, DEALER, ROUTER)
+
+	// Test
+	emptyDelimiter := []byte{}
+	routeHeader := [][]byte{tc.identity, emptyDelimiter}
+	dealerHeader := [][]byte{emptyDelimiter}
+	replyMsg := [][]byte{[]byte("Reqly")}
+	requestMsg := [][]byte{[]byte("Request"), []byte("Hello, world!")}
+	sendDropMsg := append(dealerHeader, replyMsg...)
+	sendRequestMsg := append(dealerHeader, requestMsg...)
+	recvRequestMsg := append(routeHeader, requestMsg...)
+	sendReplyMsg := append(routeHeader, replyMsg...)
+	recvReplyMsg := append(dealerHeader, replyMsg...)
+
+	tc.connectAdapter.TxChan() <- sendDropMsg
+	tc.connectAdapter.Close()
+	tc.connectSocket.SetLinger(0)
+	tc.connectSocket.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	rxChan := tc.bindAdapter.RxChan()
+	// drop all messages in the channel
+drainLoop:
+	for {
+		select {
+		case _, ok := <-rxChan:
+			if !ok {
+				break drainLoop
+			}
+		default:
+			break drainLoop
+		}
+	}
+
+	var err error
+	tc.connectSocket, err = NewSocket(DEALER)
+	requireNoError(t, err)
+	err = tc.connectSocket.SetIdentity(string(tc.identity))
+	requireNoError(t, err)
+	err = tc.connectSocket.Connect(tc.socketAddr)
+	requireNoError(t, err)
+	tc.connectAdapter = NewChanAdapter(tc.connectSocket, tc.rxChanSize, tc.txChanSize)
+	tc.connectAdapter.Start(context.Background())
+	defer tc.connectAdapter.Close()
+
+	tc.connectAdapter.TxChan() <- sendRequestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvRequestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- sendReplyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvReplyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterPub2Sub(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, SUB, PUB)
+
+	// SUB socket needs to subscribe to receive messages
+	tc.connectSocket.SetSubscribe("")
+
+	// Allow some time for subscription to propagate
+	time.Sleep(50 * time.Millisecond)
+
+	// Test
+	pubMsg := [][]byte{[]byte("Hello, subscribers!")}
+
+	tc.bindAdapter.TxChan() <- pubMsg
+	gotSubMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, pubMsg, gotSubMsg, "SUB socket received wrong message")
+}
+
+func TestChanAdapterPush2Pull(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, PUSH, PULL)
+
+	// Test
+	pushMsg := [][]byte{[]byte("Work item"), []byte("data")}
+
+	tc.connectAdapter.TxChan() <- pushMsg
+	gotPullMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, pushMsg, gotPullMsg, "PULL socket received wrong message")
+}
+
+func TestChanAdapterPair2Pair(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, PAIR, PAIR)
+
+	// Test bidirectional communication
+	msg1 := [][]byte{[]byte("Message from connect")}
+	msg2 := [][]byte{[]byte("Message from bind")}
+
+	tc.connectAdapter.TxChan() <- msg1
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, msg1, gotBindMsg, "PAIR bind received wrong message")
+
+	tc.bindAdapter.TxChan() <- msg2
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, msg2, gotConnectMsg, "PAIR connect received wrong message")
+}
+
+func TestChanAdapterEmptyMessage(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test empty message parts
+	emptyMsg := [][]byte{[]byte{}}
+
+	tc.connectAdapter.TxChan() <- emptyMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, emptyMsg, gotBindMsg, "bindAdapter received wrong empty message")
+
+	tc.bindAdapter.TxChan() <- emptyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, emptyMsg, gotConnectMsg, "connectAdapter received wrong empty message")
+}
+
+func TestChanAdapterLargeMessage(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test large message (1MB)
+	largeData := make([]byte, 1024*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+	largeMsg := [][]byte{largeData}
+
+	tc.connectAdapter.TxChan() <- largeMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, largeMsg, gotBindMsg, "bindAdapter received wrong large message")
+
+	ackMsg := [][]byte{[]byte("ACK")}
+	tc.bindAdapter.TxChan() <- ackMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, ackMsg, gotConnectMsg, "connectAdapter received wrong ack message")
+}
+
+func TestChanAdapterMultipartMessages(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test message with multiple parts
+	multipartMsg := [][]byte{
+		[]byte("part1"),
+		[]byte("part2"),
+		[]byte("part3"),
+		[]byte("part4"),
+	}
+
+	tc.connectAdapter.TxChan() <- multipartMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, multipartMsg, gotBindMsg, "bindAdapter received wrong multipart message")
+
+	replyMsg := [][]byte{[]byte("reply"), []byte("with"), []byte("multiple"), []byte("parts")}
+	tc.bindAdapter.TxChan() <- replyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, replyMsg, gotConnectMsg, "connectAdapter received wrong multipart reply")
+}
+
+func TestChanAdapterCloseBeforeStart(t *testing.T) {
+	socketAddr := fmt.Sprintf("inproc://test-%d", time.Now().UnixNano())
+
+	bindSocket, _ := NewSocket(REP)
+	bindSocket.Bind(socketAddr)
+	adapter := NewChanAdapter(bindSocket, 10, 10)
+
+	// Close before starting - should not panic
+	adapter.Close()
+
+	// Don't call Start after Close as it may cause issues
+	// The test is to verify that Close before Start doesn't cause problems
+
+	// Final cleanup
+	bindSocket.SetLinger(0)
+	bindSocket.Close()
+}
+
+func TestChanAdapterChannelSizes(t *testing.T) {
+	// Test with different channel buffer sizes
+	testCases := []struct {
+		rxSize, txSize int
+	}{
+		{0, 0},    // Unbuffered
+		{1, 1},    // Minimal buffer
+		{100, 50}, // Different sizes
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("rx:%d,tx:%d", tc.rxSize, tc.txSize), func(t *testing.T) {
+			testCase := ChanAdapterTestCase{
+				socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+				rxChanSize: tc.rxSize,
+				txChanSize: tc.txSize,
+			}
+			testCase.setUp(t, REQ, REP)
+
+			// Basic functionality test
+			testMsg := [][]byte{[]byte("test message")}
+			testCase.connectAdapter.TxChan() <- testMsg
+			gotMsg, ok := <-testCase.bindAdapter.RxChan()
+			requireTrue(t, ok, "Should receive message")
+			assertByteArrayEqual(t, testMsg, gotMsg, "Message should match")
+		})
+	}
+}
+
+// Helper functions to replace testify assertions
+
+func assertByteArrayEqual(t *testing.T, expected, actual [][]byte, msg string) {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.Errorf("%s: length mismatch: expected %d, got %d", msg, len(expected), len(actual))
+		return
+	}
+	for i := range expected {
+		if len(expected[i]) != len(actual[i]) {
+			t.Errorf("%s: length mismatch at index %d: expected %d, got %d", msg, i, len(expected[i]), len(actual[i]))
+			return
+		}
+		for j := range expected[i] {
+			if expected[i][j] != actual[i][j] {
+				t.Errorf("%s: mismatch at index [%d][%d]: expected %d, got %d", msg, i, j, expected[i][j], actual[i][j])
+				return
+			}
+		}
+	}
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func requireTrue(t *testing.T, condition bool, msg string) {
+	t.Helper()
+	if !condition {
+		t.Fatalf("condition not met: %s", msg)
+	}
+}
+
+func TestChanAdapterConcurrentAccess(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 100,
+		txChanSize: 100,
+	}
+	tc.setUp(t, DEALER, ROUTER)
+
+	const numGoroutines = 10
+	const messagesPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2) // senders + receivers
+
+	// Multiple goroutines sending messages
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				msg := [][]byte{[]byte{}, []byte(fmt.Sprintf("msg-%d-%d", id, j))}
+				tc.connectAdapter.TxChan() <- msg
+			}
+		}(i)
+	}
+
+	// Multiple goroutines receiving messages
+	received := make(chan [][]byte, numGoroutines*messagesPerGoroutine)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				select {
+				case msg := <-tc.bindAdapter.RxChan():
+					received <- msg
+				case <-time.After(5 * time.Second):
+					t.Errorf("Timeout waiting for message")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(received)
+
+	// Verify we received all messages
+	count := 0
+	for range received {
+		count++
+	}
+
+	if count != numGoroutines*messagesPerGoroutine {
+		t.Errorf("Expected %d messages, got %d", numGoroutines*messagesPerGoroutine, count)
+	}
+}
+
+func TestChanAdapterHighVolumeMessages(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 1000,
+		txChanSize: 1000,
+	}
+	tc.setUp(t, PUSH, PULL)
+
+	const numMessages = 1000
+	done := make(chan bool)
+
+	// Receiver goroutine
+	go func() {
+		for i := 0; i < numMessages; i++ {
+			select {
+			case msg := <-tc.bindAdapter.RxChan():
+				expected := fmt.Sprintf("message-%d", i)
+				if string(msg[0]) != expected {
+					t.Errorf("Expected %s, got %s", expected, string(msg[0]))
+				}
+			case <-time.After(5 * time.Second):
+				t.Errorf("Timeout waiting for message %d", i)
+				return
+			}
+		}
+		done <- true
+	}()
+
+	// Send messages rapidly
+	for i := 0; i < numMessages; i++ {
+		msg := [][]byte{[]byte(fmt.Sprintf("message-%d", i))}
+		tc.connectAdapter.TxChan() <- msg
+	}
+
+	// Wait for completion
+	select {
+	case <-done:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Error("Test timed out")
+	}
+}
+
+func TestChanAdapterBackpressure(t *testing.T) {
+	// Small buffer to test backpressure
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 2, // Very small buffer
+		txChanSize: 2,
+	}
+	// Use PUSH-PULL instead of REQ-REP to avoid strict alternating requirements
+	tc.setUp(t, PUSH, PULL)
+
+	// Send multiple messages without reading them
+	// This should test backpressure handling
+	sent := 0
+sendLoop:
+	for i := 0; i < 5; i++ {
+		msg := [][]byte{[]byte(fmt.Sprintf("msg-%d", i))}
+		select {
+		case tc.connectAdapter.TxChan() <- msg:
+			sent++
+		case <-time.After(100 * time.Millisecond):
+			// This is expected due to backpressure
+			break sendLoop
+		}
+	}
+
+	// Now start reading messages
+	for i := 0; i < sent; i++ {
+		select {
+		case <-tc.bindAdapter.RxChan():
+			// Good, received a message
+		case <-time.After(1 * time.Second):
+			t.Errorf("Timeout receiving message %d", i)
+		}
+	}
+}
+
+func TestChanAdapterErrorRecovery(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Send a normal message first
+	normalMsg := [][]byte{[]byte("normal")}
+	tc.connectAdapter.TxChan() <- normalMsg
+
+	_, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "Should receive normal message")
+
+	// Force close the underlying socket to simulate an error
+	tc.connectSocket.Close()
+
+	// Give some time for the error to propagate
+	time.Sleep(100 * time.Millisecond)
+
+	// The adapter should handle this gracefully with no panic or deadlock
+}
+
+func TestChanAdapterMessageOrder(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 100,
+		txChanSize: 100,
+	}
+	tc.setUp(t, PUSH, PULL)
+
+	const numMessages = 100
+
+	// Send messages in order
+	go func() {
+		for i := 0; i < numMessages; i++ {
+			msg := [][]byte{[]byte(fmt.Sprintf("%d", i))}
+			tc.connectAdapter.TxChan() <- msg
+		}
+	}()
+
+	// Receive messages and verify order
+	for i := 0; i < numMessages; i++ {
+		select {
+		case msg := <-tc.bindAdapter.RxChan():
+			expected := fmt.Sprintf("%d", i)
+			if string(msg[0]) != expected {
+				t.Errorf("Message order violated: expected %s, got %s", expected, string(msg[0]))
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for message %d", i)
+		}
+	}
+}
+
+func TestChanAdapterZeroByteMessage(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Send message with zero-length parts
+	zeroMsg := [][]byte{[]byte{}, []byte{}, []byte("actual-data")}
+	tc.connectAdapter.TxChan() <- zeroMsg
+
+	gotMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "Should receive zero-byte message")
+	assertByteArrayEqual(t, zeroMsg, gotMsg, "Zero-byte message should be preserved")
+}

--- a/draft/chanadapter.go
+++ b/draft/chanadapter.go
@@ -1,0 +1,272 @@
+package zmq4
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+)
+
+// ChanAdapter provides a Go channel-based interface for ZeroMQ sockets.
+// It bridges the gap between ZeroMQ's message-passing model and Go's channel-based
+// concurrency model by creating receive (Rx) and transmit (Tx) channels that can be
+// used in standard Go select statements and channel operations.
+//
+// The adapter runs two internal goroutines: one for routing incoming messages
+// from the ZMQ socket to the Rx channel, and another for sending messages
+// from the Tx channel to the ZMQ socket.
+type ChanAdapter struct {
+	socket         *Socket
+	pairAddr       string
+	rxChan         chan [][]byte
+	txChan         chan [][]byte
+	sendBufferChan chan [][]byte
+	closeOnce      sync.Once
+	closeChan      func()
+	ctxCancel      func()
+	wg             sync.WaitGroup
+}
+
+var (
+	chanAdapterUniqueID atomic.Uint64
+	chanAdapterOpClose  = []byte{0x0} // the adapter is being closed
+	chanAdapterOpSend   = []byte{0x1} // send a message to the ZMQ socket
+)
+
+// NewChanAdapter creates a new ChanAdapter for the given ZMQ socket.
+// The rxChanSize parameter specifies the buffer size for the receive channel,
+// and txChanSize specifies the buffer size for the transmit channel.
+//
+// The adapter must be started with Start() and should be closed with Close()
+// when no longer needed to ensure proper cleanup of resources.
+//
+// Example:
+//
+//	socket, err := zmq4.NewSocket(zmq4.REQ)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	socket.Connect("<socket-address>")
+//
+//	adapter := zmq4.NewChanAdapter(socket, 100, 100)
+//	defer adapter.Close()
+//
+//	// Start the adapter with a context for cancellation
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//	adapter.Start(ctx)
+//
+//	msg := [][]byte{[]byte("Hello"), []byte("World")}
+//	adapter.TxChan() <- msg
+//
+//	rxChan := adapter.RxChan()
+//
+//	select {
+//	case msg, ok := <-rxChan:
+//		// Handle incoming message
+//	case <-time.After(time.Second):
+//		// Handle timeout
+//	}
+func NewChanAdapter(socket *Socket, rxChanSize int, txChanSize int) *ChanAdapter {
+	pairAddr := fmt.Sprintf("inproc://zmq-chan-transceiver-%d", chanAdapterUniqueID.Add(1))
+	rxChan := make(chan [][]byte, rxChanSize)
+	txChan := make(chan [][]byte, txChanSize)
+	sendBufferChan := make(chan [][]byte) // unbuffered channel
+
+	closeChan := func() {
+		close(rxChan)
+		close(txChan)
+		close(sendBufferChan)
+	}
+
+	return &ChanAdapter{
+		socket:         socket,
+		pairAddr:       pairAddr,
+		rxChan:         rxChan,
+		txChan:         txChan,
+		sendBufferChan: sendBufferChan,
+		closeChan:      closeChan,
+	}
+}
+
+// RxChan returns a receive-only channel for incoming messages from the ZMQ socket.
+// Messages received on the underlying ZMQ socket will be forwarded to this channel
+// as byte slice arrays, where each element represents a message part in multi-part messages.
+//
+// The channel will be closed when the adapter is shut down.
+func (t *ChanAdapter) RxChan() <-chan [][]byte {
+	return t.rxChan
+}
+
+// TxChan returns a send-only channel for outgoing messages to the ZMQ socket.
+// Messages sent to this channel will be forwarded to the underlying ZMQ socket.
+// Each message should be provided as a byte slice array, where each element
+// represents a message part for multi-part messages.
+//
+// The channel will be closed when the adapter is shut down.
+func (t *ChanAdapter) TxChan() chan<- [][]byte {
+	return t.txChan
+}
+
+// Start begins the adapter's operation by launching two background goroutines:
+// one for routing messages from the ZMQ socket to the receive channel, and
+// another for routing messages from the transmit channel to the ZMQ socket.
+//
+// The provided context can be used to cancel the adapter's operation.
+// When the context is cancelled or Close() is called, both goroutines will
+// be shut down gracefully.
+//
+// Start should only be called once per adapter instance.
+func (t *ChanAdapter) Start(ctx context.Context) {
+	childCtx, cancel := context.WithCancel(ctx)
+	t.ctxCancel = cancel
+
+	t.wg.Add(2)
+	go t.runRouterLoop(childCtx)
+	go t.runSenderLoop(childCtx)
+}
+
+// runRouterLoop handles incoming messages from the ZMQ socket and internal
+// coordination messages from the sender loop. It forwards socket messages
+// to the receive channel and processes send requests from the sender loop.
+func (t *ChanAdapter) runRouterLoop(_ context.Context) {
+	var err error
+	defer t.wg.Done()
+	defer t.ctxCancel()
+
+	pair, err := NewSocket(PAIR)
+	if err != nil {
+		log.Println("E: failed to create PAIR socket")
+		return
+	}
+	defer pair.Close()
+
+	err = pair.Bind(t.pairAddr)
+	if err != nil {
+		log.Println("E: failed to connect PAIR socket")
+		return
+	}
+
+	poller := NewPoller()
+	poller.Add(t.socket, POLLIN)
+	poller.Add(pair, POLLIN)
+
+	for {
+		events, err := poller.PollAll(-1)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		if len(events) == 0 {
+			log.Println("I: socket timeout")
+			continue
+		}
+
+		for _, item := range events {
+			switch s := item.Socket; s {
+			case pair:
+				if item.Events&POLLIN != 0 {
+					opCode, err := pair.RecvBytes(0)
+					if err != nil {
+						log.Println(err)
+						continue
+					}
+
+					if bytes.Equal(opCode, chanAdapterOpClose) {
+						return
+					} else if bytes.Equal(opCode, chanAdapterOpSend) {
+						msg, ok := <-t.sendBufferChan
+						if !ok {
+							log.Println("E: sendBufferChan is closed")
+							return
+						}
+						// send the message payload to the ZMQ socket
+						_, err = t.socket.SendMessage(msg)
+						if err != nil {
+							log.Println("E: failed to send message to socket. ", err)
+							continue
+						}
+					}
+				}
+			case t.socket:
+				if item.Events&POLLIN != 0 {
+					// process incoming messages
+					msg, err := t.socket.RecvMessageBytes(0)
+					if err != nil {
+						log.Println(err)
+						continue
+					}
+					// forward the message to rxChan
+					t.rxChan <- msg
+				}
+			}
+
+		}
+	}
+
+}
+
+// runSenderLoop handles outgoing messages from the transmit channel.
+// It coordinates with the router loop via an internal PAIR socket to
+// ensure thread-safe message transmission to the ZMQ socket.
+func (t *ChanAdapter) runSenderLoop(ctx context.Context) {
+	var err error
+	defer t.wg.Done()
+	defer t.ctxCancel()
+
+	pair, err := NewSocket(PAIR)
+	if err != nil {
+		log.Println("E: failed to create PAIR socket")
+		return
+	}
+	defer pair.Close()
+
+	err = pair.Connect(t.pairAddr)
+	if err != nil {
+		log.Println("E: failed to connect PAIR socket")
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// ensure the router loop is closed gracefully
+			_, err = pair.SendBytes(chanAdapterOpClose, 0)
+			if err != nil {
+				log.Println("E: failed to send close message")
+			}
+			return
+		case msg, ok := <-t.txChan:
+			if !ok {
+				log.Println("E: txChan is closed")
+				return
+			}
+			_, err = pair.SendBytes(chanAdapterOpSend, 0)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+			// block until the message payload is recieved by Router loop
+			t.sendBufferChan <- msg
+		}
+	}
+}
+
+// Close gracefully shuts down the adapter by cancelling the context,
+// waiting for all goroutines to complete, and closing all channels.
+// It's safe to call Close multiple times.
+//
+// After Close is called, the receive and transmit channels will be closed
+// and no further message processing will occur.
+func (t *ChanAdapter) Close() {
+	if t.ctxCancel != nil {
+		t.ctxCancel()
+	}
+	t.wg.Wait()
+	if t.closeChan != nil {
+		t.closeOnce.Do(t.closeChan)
+	}
+}

--- a/draft/chanadapter_test.go
+++ b/draft/chanadapter_test.go
@@ -1,0 +1,638 @@
+package zmq4
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type ChanAdapterTestCase struct {
+	// Begin of test case parameters
+	socketAddr string
+	rxChanSize int
+	txChanSize int
+	identity   []byte
+	// End of test case parameters
+	bindSocket     *Socket
+	bindAdapter    *ChanAdapter
+	cancel         func()
+	connectSocket  *Socket
+	connectAdapter *ChanAdapter
+}
+
+func (tc *ChanAdapterTestCase) setUp(t *testing.T, connectType, bindType Type) {
+	tc.bindSocket, _ = NewSocket(bindType)
+	tc.bindSocket.Bind(tc.socketAddr)
+	tc.bindAdapter = NewChanAdapter(tc.bindSocket, tc.rxChanSize, tc.txChanSize)
+
+	tc.connectSocket, _ = NewSocket(connectType)
+	if tc.identity != nil {
+		tc.connectSocket.SetIdentity(string(tc.identity[:]))
+	}
+	tc.connectSocket.Connect(tc.socketAddr)
+	tc.connectAdapter = NewChanAdapter(tc.connectSocket, tc.rxChanSize, tc.txChanSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tc.cancel = cancel
+	tc.bindAdapter.Start(ctx)
+	tc.connectAdapter.Start(ctx)
+
+	t.Cleanup(func() {
+		if tc.cancel != nil {
+			tc.cancel()
+		}
+		if tc.bindAdapter != nil {
+			tc.bindAdapter.Close()
+		}
+		if tc.connectAdapter != nil {
+			tc.connectAdapter.Close()
+		}
+		if tc.bindSocket != nil {
+			tc.bindSocket.SetLinger(0)
+			tc.bindSocket.Close()
+		}
+		if tc.connectSocket != nil {
+			tc.connectSocket.SetLinger(0)
+			tc.connectSocket.Close()
+		}
+	})
+}
+
+// Test cases
+func TestChanAdapterReq2Rep(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test
+	requestMsg := [][]byte{[]byte("Hello, world!")}
+	replyMsg := [][]byte{[]byte("Ack")}
+
+	tc.connectAdapter.TxChan() <- requestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, requestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- replyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, replyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterReq2Router(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+		identity:   []byte("client-12345"),
+	}
+	tc.setUp(t, REQ, ROUTER)
+
+	// Test
+	emptyDelimiter := []byte{}
+	routeHeader := [][]byte{tc.identity, emptyDelimiter}
+	replyMsg := [][]byte{[]byte("Reply")}
+	requestMsg := [][]byte{[]byte("Request"), []byte("Hello, world!")}
+	recvRequestMsg := append(routeHeader, requestMsg...)
+	sendReplyMsg := append(routeHeader, replyMsg...)
+
+	tc.connectAdapter.TxChan() <- requestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvRequestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- sendReplyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, replyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterDealer2Router(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+		identity:   []byte("client-12345"),
+	}
+	tc.setUp(t, DEALER, ROUTER)
+
+	// Test
+	emptyDelimiter := []byte{}
+	routeHeader := [][]byte{tc.identity, emptyDelimiter}
+	dealerHeader := [][]byte{emptyDelimiter}
+	replyMsg := [][]byte{[]byte("Reqly")}
+	requestMsg := [][]byte{[]byte("Request"), []byte("Hello, world!")}
+	sendRequestMsg := append(dealerHeader, requestMsg...)
+	recvRequestMsg := append(routeHeader, requestMsg...)
+	sendReplyMsg := append(routeHeader, replyMsg...)
+	recvReplyMsg := append(dealerHeader, replyMsg...)
+
+	tc.connectAdapter.TxChan() <- sendRequestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvRequestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- sendReplyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvReplyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterReconnectDealer2Router(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+		identity:   []byte("client-12345"),
+	}
+	tc.setUp(t, DEALER, ROUTER)
+
+	// Test
+	emptyDelimiter := []byte{}
+	routeHeader := [][]byte{tc.identity, emptyDelimiter}
+	dealerHeader := [][]byte{emptyDelimiter}
+	replyMsg := [][]byte{[]byte("Reqly")}
+	requestMsg := [][]byte{[]byte("Request"), []byte("Hello, world!")}
+	sendDropMsg := append(dealerHeader, replyMsg...)
+	sendRequestMsg := append(dealerHeader, requestMsg...)
+	recvRequestMsg := append(routeHeader, requestMsg...)
+	sendReplyMsg := append(routeHeader, replyMsg...)
+	recvReplyMsg := append(dealerHeader, replyMsg...)
+
+	tc.connectAdapter.TxChan() <- sendDropMsg
+	tc.connectAdapter.Close()
+	tc.connectSocket.SetLinger(0)
+	tc.connectSocket.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	rxChan := tc.bindAdapter.RxChan()
+	// drop all messages in the channel
+drainLoop:
+	for {
+		select {
+		case _, ok := <-rxChan:
+			if !ok {
+				break drainLoop
+			}
+		default:
+			break drainLoop
+		}
+	}
+
+	var err error
+	tc.connectSocket, err = NewSocket(DEALER)
+	requireNoError(t, err)
+	err = tc.connectSocket.SetIdentity(string(tc.identity))
+	requireNoError(t, err)
+	err = tc.connectSocket.Connect(tc.socketAddr)
+	requireNoError(t, err)
+	tc.connectAdapter = NewChanAdapter(tc.connectSocket, tc.rxChanSize, tc.txChanSize)
+	tc.connectAdapter.Start(context.Background())
+	defer tc.connectAdapter.Close()
+
+	tc.connectAdapter.TxChan() <- sendRequestMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvRequestMsg, gotBindMsg, "bindAdapter received wrong message")
+
+	tc.bindAdapter.TxChan() <- sendReplyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, recvReplyMsg, gotConnectMsg, "connectAdapter received wrong message")
+}
+
+func TestChanAdapterPub2Sub(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, SUB, PUB)
+
+	// SUB socket needs to subscribe to receive messages
+	tc.connectSocket.SetSubscribe("")
+
+	// Allow some time for subscription to propagate
+	time.Sleep(50 * time.Millisecond)
+
+	// Test
+	pubMsg := [][]byte{[]byte("Hello, subscribers!")}
+
+	tc.bindAdapter.TxChan() <- pubMsg
+	gotSubMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, pubMsg, gotSubMsg, "SUB socket received wrong message")
+}
+
+func TestChanAdapterPush2Pull(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, PUSH, PULL)
+
+	// Test
+	pushMsg := [][]byte{[]byte("Work item"), []byte("data")}
+
+	tc.connectAdapter.TxChan() <- pushMsg
+	gotPullMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, pushMsg, gotPullMsg, "PULL socket received wrong message")
+}
+
+func TestChanAdapterPair2Pair(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, PAIR, PAIR)
+
+	// Test bidirectional communication
+	msg1 := [][]byte{[]byte("Message from connect")}
+	msg2 := [][]byte{[]byte("Message from bind")}
+
+	tc.connectAdapter.TxChan() <- msg1
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, msg1, gotBindMsg, "PAIR bind received wrong message")
+
+	tc.bindAdapter.TxChan() <- msg2
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, msg2, gotConnectMsg, "PAIR connect received wrong message")
+}
+
+func TestChanAdapterEmptyMessage(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test empty message parts
+	emptyMsg := [][]byte{[]byte{}}
+
+	tc.connectAdapter.TxChan() <- emptyMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, emptyMsg, gotBindMsg, "bindAdapter received wrong empty message")
+
+	tc.bindAdapter.TxChan() <- emptyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, emptyMsg, gotConnectMsg, "connectAdapter received wrong empty message")
+}
+
+func TestChanAdapterLargeMessage(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test large message (1MB)
+	largeData := make([]byte, 1024*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+	largeMsg := [][]byte{largeData}
+
+	tc.connectAdapter.TxChan() <- largeMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, largeMsg, gotBindMsg, "bindAdapter received wrong large message")
+
+	ackMsg := [][]byte{[]byte("ACK")}
+	tc.bindAdapter.TxChan() <- ackMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, ackMsg, gotConnectMsg, "connectAdapter received wrong ack message")
+}
+
+func TestChanAdapterMultipartMessages(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Test message with multiple parts
+	multipartMsg := [][]byte{
+		[]byte("part1"),
+		[]byte("part2"),
+		[]byte("part3"),
+		[]byte("part4"),
+	}
+
+	tc.connectAdapter.TxChan() <- multipartMsg
+	gotBindMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "bindAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, multipartMsg, gotBindMsg, "bindAdapter received wrong multipart message")
+
+	replyMsg := [][]byte{[]byte("reply"), []byte("with"), []byte("multiple"), []byte("parts")}
+	tc.bindAdapter.TxChan() <- replyMsg
+	gotConnectMsg, ok := <-tc.connectAdapter.RxChan()
+	requireTrue(t, ok, "connectAdapter.RxChan() should return a message")
+	assertByteArrayEqual(t, replyMsg, gotConnectMsg, "connectAdapter received wrong multipart reply")
+}
+
+func TestChanAdapterCloseBeforeStart(t *testing.T) {
+	socketAddr := fmt.Sprintf("inproc://test-%d", time.Now().UnixNano())
+
+	bindSocket, _ := NewSocket(REP)
+	bindSocket.Bind(socketAddr)
+	adapter := NewChanAdapter(bindSocket, 10, 10)
+
+	// Close before starting - should not panic
+	adapter.Close()
+
+	// Don't call Start after Close as it may cause issues
+	// The test is to verify that Close before Start doesn't cause problems
+
+	// Final cleanup
+	bindSocket.SetLinger(0)
+	bindSocket.Close()
+}
+
+func TestChanAdapterChannelSizes(t *testing.T) {
+	// Test with different channel buffer sizes
+	testCases := []struct {
+		rxSize, txSize int
+	}{
+		{0, 0},    // Unbuffered
+		{1, 1},    // Minimal buffer
+		{100, 50}, // Different sizes
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("rx:%d,tx:%d", tc.rxSize, tc.txSize), func(t *testing.T) {
+			testCase := ChanAdapterTestCase{
+				socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+				rxChanSize: tc.rxSize,
+				txChanSize: tc.txSize,
+			}
+			testCase.setUp(t, REQ, REP)
+
+			// Basic functionality test
+			testMsg := [][]byte{[]byte("test message")}
+			testCase.connectAdapter.TxChan() <- testMsg
+			gotMsg, ok := <-testCase.bindAdapter.RxChan()
+			requireTrue(t, ok, "Should receive message")
+			assertByteArrayEqual(t, testMsg, gotMsg, "Message should match")
+		})
+	}
+}
+
+// Helper functions to replace testify assertions
+
+func assertByteArrayEqual(t *testing.T, expected, actual [][]byte, msg string) {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.Errorf("%s: length mismatch: expected %d, got %d", msg, len(expected), len(actual))
+		return
+	}
+	for i := range expected {
+		if len(expected[i]) != len(actual[i]) {
+			t.Errorf("%s: length mismatch at index %d: expected %d, got %d", msg, i, len(expected[i]), len(actual[i]))
+			return
+		}
+		for j := range expected[i] {
+			if expected[i][j] != actual[i][j] {
+				t.Errorf("%s: mismatch at index [%d][%d]: expected %d, got %d", msg, i, j, expected[i][j], actual[i][j])
+				return
+			}
+		}
+	}
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func requireTrue(t *testing.T, condition bool, msg string) {
+	t.Helper()
+	if !condition {
+		t.Fatalf("condition not met: %s", msg)
+	}
+}
+
+func TestChanAdapterConcurrentAccess(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 100,
+		txChanSize: 100,
+	}
+	tc.setUp(t, DEALER, ROUTER)
+
+	const numGoroutines = 10
+	const messagesPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2) // senders + receivers
+
+	// Multiple goroutines sending messages
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				msg := [][]byte{[]byte{}, []byte(fmt.Sprintf("msg-%d-%d", id, j))}
+				tc.connectAdapter.TxChan() <- msg
+			}
+		}(i)
+	}
+
+	// Multiple goroutines receiving messages
+	received := make(chan [][]byte, numGoroutines*messagesPerGoroutine)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				select {
+				case msg := <-tc.bindAdapter.RxChan():
+					received <- msg
+				case <-time.After(5 * time.Second):
+					t.Errorf("Timeout waiting for message")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(received)
+
+	// Verify we received all messages
+	count := 0
+	for range received {
+		count++
+	}
+
+	if count != numGoroutines*messagesPerGoroutine {
+		t.Errorf("Expected %d messages, got %d", numGoroutines*messagesPerGoroutine, count)
+	}
+}
+
+func TestChanAdapterHighVolumeMessages(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 1000,
+		txChanSize: 1000,
+	}
+	tc.setUp(t, PUSH, PULL)
+
+	const numMessages = 1000
+	done := make(chan bool)
+
+	// Receiver goroutine
+	go func() {
+		for i := 0; i < numMessages; i++ {
+			select {
+			case msg := <-tc.bindAdapter.RxChan():
+				expected := fmt.Sprintf("message-%d", i)
+				if string(msg[0]) != expected {
+					t.Errorf("Expected %s, got %s", expected, string(msg[0]))
+				}
+			case <-time.After(5 * time.Second):
+				t.Errorf("Timeout waiting for message %d", i)
+				return
+			}
+		}
+		done <- true
+	}()
+
+	// Send messages rapidly
+	for i := 0; i < numMessages; i++ {
+		msg := [][]byte{[]byte(fmt.Sprintf("message-%d", i))}
+		tc.connectAdapter.TxChan() <- msg
+	}
+
+	// Wait for completion
+	select {
+	case <-done:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Error("Test timed out")
+	}
+}
+
+func TestChanAdapterBackpressure(t *testing.T) {
+	// Small buffer to test backpressure
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 2, // Very small buffer
+		txChanSize: 2,
+	}
+	// Use PUSH-PULL instead of REQ-REP to avoid strict alternating requirements
+	tc.setUp(t, PUSH, PULL)
+
+	// Send multiple messages without reading them
+	// This should test backpressure handling
+	sent := 0
+sendLoop:
+	for i := 0; i < 5; i++ {
+		msg := [][]byte{[]byte(fmt.Sprintf("msg-%d", i))}
+		select {
+		case tc.connectAdapter.TxChan() <- msg:
+			sent++
+		case <-time.After(100 * time.Millisecond):
+			// This is expected due to backpressure
+			break sendLoop
+		}
+	}
+
+	// Now start reading messages
+	for i := 0; i < sent; i++ {
+		select {
+		case <-tc.bindAdapter.RxChan():
+			// Good, received a message
+		case <-time.After(1 * time.Second):
+			t.Errorf("Timeout receiving message %d", i)
+		}
+	}
+}
+
+func TestChanAdapterErrorRecovery(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Send a normal message first
+	normalMsg := [][]byte{[]byte("normal")}
+	tc.connectAdapter.TxChan() <- normalMsg
+
+	_, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "Should receive normal message")
+
+	// Force close the underlying socket to simulate an error
+	tc.connectSocket.Close()
+
+	// Give some time for the error to propagate
+	time.Sleep(100 * time.Millisecond)
+
+	// The adapter should handle this gracefully with no panic or deadlock
+}
+
+func TestChanAdapterMessageOrder(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 100,
+		txChanSize: 100,
+	}
+	tc.setUp(t, PUSH, PULL)
+
+	const numMessages = 100
+
+	// Send messages in order
+	go func() {
+		for i := 0; i < numMessages; i++ {
+			msg := [][]byte{[]byte(fmt.Sprintf("%d", i))}
+			tc.connectAdapter.TxChan() <- msg
+		}
+	}()
+
+	// Receive messages and verify order
+	for i := 0; i < numMessages; i++ {
+		select {
+		case msg := <-tc.bindAdapter.RxChan():
+			expected := fmt.Sprintf("%d", i)
+			if string(msg[0]) != expected {
+				t.Errorf("Message order violated: expected %s, got %s", expected, string(msg[0]))
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for message %d", i)
+		}
+	}
+}
+
+func TestChanAdapterZeroByteMessage(t *testing.T) {
+	tc := ChanAdapterTestCase{
+		socketAddr: fmt.Sprintf("inproc://test-%d", time.Now().UnixNano()),
+		rxChanSize: 10,
+		txChanSize: 10,
+	}
+	tc.setUp(t, REQ, REP)
+
+	// Send message with zero-length parts
+	zeroMsg := [][]byte{[]byte{}, []byte{}, []byte("actual-data")}
+	tc.connectAdapter.TxChan() <- zeroMsg
+
+	gotMsg, ok := <-tc.bindAdapter.RxChan()
+	requireTrue(t, ok, "Should receive zero-byte message")
+	assertByteArrayEqual(t, zeroMsg, gotMsg, "Zero-byte message should be preserved")
+}


### PR DESCRIPTION
## Description
This PR introduces a new `ChanAdapter` component that provides a Go channel-based interface for ZeroMQ sockets. The adapter bridges the gap between ZeroMQ's message-passing model and Go's channel-based concurrency model by creating receive (Rx) and transmit (Tx) channels that can be used in standard Go select statements and channel operations.

## Key Features
- Provides a Go-native channel interface for ZeroMQ socket operations
- Supports both single and multi-part messages
- Thread-safe message handling with internal coordination
- Graceful shutdown and resource cleanup
- Comprehensive test coverage for various socket types and scenarios

## Highlights
- Native Go Concurrency Patterns
- Thread Safety and Coordination
- Flexibility and Simplicity
- Comprehensive Testing

## Example Usage
```go
socket, err := zmq4.NewSocket(zmq4.REQ)
if err != nil {
    log.Fatal(err)
}
socket.Connect("<socket-address>")

adapter := zmq4.NewChanAdapter(socket, 100, 100)
defer adapter.Close()

// Start the adapter with a context for cancellation
ctx, cancel := context.WithCancel(context.Background())
defer cancel()
adapter.Start(ctx)

// Send a message
msg := [][]byte{[]byte("Hello"), []byte("World")}
adapter.TxChan() <- msg

// Receive messages
rxChan := adapter.RxChan()
select {
case msg, ok := <-rxChan:
    // Handle incoming message
case <-time.After(time.Second):
    // Handle timeout
}
```